### PR TITLE
feat: configure pages and adjust permissions from the backend

### DIFF
--- a/service-desk-frontend/src/config/pagesConfig.ts
+++ b/service-desk-frontend/src/config/pagesConfig.ts
@@ -1,0 +1,15 @@
+// src/config/pagesConfig.ts
+
+// Definindo a interface Page
+export interface Page {
+    allowed_page: string; // Nome da página
+    id_page: number;      // ID da página
+}
+
+// Lista de páginas disponíveis
+export const availablePages: Page[] = [
+    { allowed_page: "ABERTURA", id_page: 1 },
+    { allowed_page: "CONSULTA", id_page: 2 },
+    { allowed_page: "CADASTRO", id_page: 3 },
+    { allowed_page: "TRATAMENTO", id_page: 4 },
+];

--- a/service-desk-frontend/src/pages/home/home.tsx
+++ b/service-desk-frontend/src/pages/home/home.tsx
@@ -1,10 +1,11 @@
+// src/pages/home/home.tsx
 import React, { useEffect } from "react";
 import { useNavigate } from "react-router-dom"; // Importe o hook useNavigate
 import { useAuth } from "../../contexts/AuthContext"; // Importe o useAuth para acessar o contexto
 
 export const Home = () => {
   const navigate = useNavigate();
-  const { isAuthenticated } = useAuth(); // Acesse o estado de autenticação
+  const { isAuthenticated, pages } = useAuth(); // Acesse o estado de autenticação
 
   useEffect(() => {
     if (!isAuthenticated) {
@@ -12,10 +13,32 @@ export const Home = () => {
     }
   }, [isAuthenticated, navigate]);
 
+  const handlePageClick = (page: string) => {
+    navigate(`/${page.toLowerCase()}`);
+  }
+
   return (
     <div>
       <h1>Bem-vindo à Home</h1>
       {/* Conteúdo da home */}
+      <br></br>
+      <div>
+        <h2>Páginas Acessíveis:</h2>
+        <br></br>
+        {pages.length > 0 ? (
+          pages.map((page) => (
+            <button
+              key={page.id_page}
+              onClick={() => handlePageClick(page.allowed_page)}
+            >
+              {page.allowed_page}
+            </button>
+          ))
+        ) : (
+          <p>Você não tem permissões para acessar nenhuma página.</p>
+        )}
+      </div>
+
     </div>
   );
 };

--- a/service-desk-frontend/src/routes/index.tsx
+++ b/service-desk-frontend/src/routes/index.tsx
@@ -1,3 +1,4 @@
+// src/routes/index.tsx
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import { Login } from "../pages/login";


### PR DESCRIPTION
- [x] Add configurations to set up system pages.
- [x] Implement retrieval of permissions from the backend to display available user pages as buttons on the screen.
- [x] Adjust the format of backend permissions: previously returned as an object, now it returns only the IDs of the pages the user has access to.